### PR TITLE
Proper iframe src generation

### DIFF
--- a/app/design/frontend/base/default/template/TIG/MyParcel2014/checkout/onepage/shipping_method/available.phtml
+++ b/app/design/frontend/base/default/template/TIG/MyParcel2014/checkout/onepage/shipping_method/available.phtml
@@ -124,7 +124,7 @@ $toggleOptions = $helper->getConfig('toggle_options', 'checkout') == '1' ? true 
 
             <?php if ($code == 'myparcel' && $useMyParcel): ?>
                 <div id="mypa-load" style="<?php echo $toggleOptions && $_rate->getCode() !== $this->getAddressShippingMethod() ? 'display: none;' : ''; ?>">
-                    <iframe id="myparcel-iframe" src="<?php echo Mage::getUrl('',array('_secure'=>true));?>/myparcel2014/checkout/checkout_options" frameborder="0" scrolling="auto" style="width: 100%;" >Bezig met laden...</iframe>
+                    <iframe id="myparcel-iframe" src="<?php echo Mage::getUrl('myparcel2014/checkout/checkout_options',array('_secure'=>true));?>" frameborder="0" scrolling="auto" style="width: 100%;" >Bezig met laden...</iframe>
                     <input style="display: none;" id="mypa-input" name="mypa-post-nl-data">
                     <input style="display: none;" type="checkbox" name='mypa-signed' id="mypa-signed">
                     <input style="display: none;" type="checkbox" name='mypa-recipient-only' id="mypa-recipient-only">


### PR DESCRIPTION
Mage::getUrl can return a URL with query string included. This results in
invalid myparcel2014 URL: example.com?___SID=xx/myparcel2014...

This commit fixes this bug.