### PR TITLE
Fix multiple shops with multiple API keys

### DIFF
--- a/app/code/community/TIG/MyParcel2014/Model/Shipment.php
+++ b/app/code/community/TIG/MyParcel2014/Model/Shipment.php
@@ -687,7 +687,10 @@ class TIG_MyParcel2014_Model_Shipment extends Mage_Core_Model_Abstract
         if($responseShipment){
             $this->updateStatus($responseShipment);
         }
-
+	    
+	if (empty($consignmentIds)) {
+            $consignmentIds = (string) $consignmentId;
+	}
 
         $this->setConsignmentId($consignmentIds);
 


### PR DESCRIPTION
There is a bug in our api with the processing of API keys from multiple shops. This is a temporary solution so that you can print MyParcel labels.